### PR TITLE
Update FinalKill.java

### DIFF
--- a/src/main/java/me/metallicgoat/MBedwarsTweaks/tweaks/messages/FinalKill.java
+++ b/src/main/java/me/metallicgoat/MBedwarsTweaks/tweaks/messages/FinalKill.java
@@ -22,8 +22,8 @@ public class FinalKill implements Listener {
                 String message = e.getDeathMessage().done(false);
                 if(arena.isBedDestroyed(team) && !message.isEmpty()){
                     message += " &b&lFINAL KILL!";
-                    e.setDeathMessage(Message.build(message));
                 }
+                e.setDeathMessage(Message.build(message));
             }
         }
     }


### PR DESCRIPTION
patch Caused by: java.lang.IllegalStateException: Instance is already freed on classic kill

i just go out from the if statement "e.setDeathMessage(Message.build(message));" and it has been work on my server


<img width="567" alt="Capture d’écran 2021-11-02 à 11 44 46" src="https://user-images.githubusercontent.com/72940478/139832393-220ac969-394e-42b9-9a03-1bdc818e390c.png">
r