### PR TITLE
(PAPI Placeholders) Fixed NPE if offlinePlayer is actually offline

### DIFF
--- a/src/main/java/me/metallicgoat/tweaksaddon/Placeholders.java
+++ b/src/main/java/me/metallicgoat/tweaksaddon/Placeholders.java
@@ -42,8 +42,16 @@ public class Placeholders extends PlaceholderExpansion {
 
   @Override
   public String onRequest(OfflinePlayer offlinePlayer, @NotNull String params) {
-    final Player player = Bukkit.getPlayer(offlinePlayer.getUniqueId());
-    final Arena arena = BedwarsAPI.getGameAPI().getSpectatingPlayers().contains(player) ? BedwarsAPI.getGameAPI().getArenaBySpectator(player) : BedwarsAPI.getGameAPI().getArenaByPlayer(player);
+    if (offlinePlayer == null)
+      return "Missing player info";
+    if (!offlinePlayer.isOnline())
+      return "Player not online";
+
+    final Player player = (Player) offlinePlayer;
+    Arena arena = BedwarsAPI.getGameAPI().getArenaByPlayer(player);
+
+    if (arena == null)
+      arena = BedwarsAPI.getGameAPI().getArenaBySpectator(player);
 
     switch (params.toLowerCase()) {
       case "next-tier": {


### PR DESCRIPTION
```
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:?]
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964) ~[?:?]
	at java.util.concurrent.ConcurrentHashMap$KeySetView.contains(ConcurrentHashMap.java:4607) ~[?:?]
	at java.util.Collections$UnmodifiableCollection.contains(Collections.java:1036) ~[?:?]
	at me.metallicgoat.tweaksaddon.Placeholders.onRequest(Placeholders.java:46) ~[?:?]
	at me.clip.placeholderapi.replacer.CharsReplacer.apply(CharsReplacer.java:119) ~[?:?]
	at me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(PlaceholderAPI.java:71) ~[?:?]
	at de.marcely.bedwars.gJ.a(PlaceholderAPI.java:42) ~[?:?]
	at de.marcely.bedwars.iP.done(Message.java:221) ~[?:?]
	at de.marcely.bedwars.iP.done(Message.java:196) ~[?:?]
	at de.marcely.bedwars.ee.d(PlayerScoreboardData.java:120) ~[?:?]
	at de.marcely.bedwars.ee.a(PlayerScoreboardData.java:113) ~[?:?]
	at de.marcely.bedwars.eg$b.av(ScoreboardRenderer.java:134) ~[?:?]
	at de.marcely.bedwars.eg.m(ScoreboardRenderer.java:69) ~[?:?]
	at de.marcely.bedwars.ed.c(DefaultScoreboardHandler.java:142) ~[?:?]
	at java.util.concurrent.ConcurrentLinkedDeque.forEach(ConcurrentLinkedDeque.java:1650) ~[?:?]
	at de.marcely.bedwars.ed.update0(DefaultScoreboardHandler.java:131) ~[?:?]
	at de.marcely.bedwars.api.game.scoreboard.ScoreboardHandler.update(ScoreboardHandler.java:171) ~[?:?]
	at de.marcely.bedwars.dw.a(Arena.java:3576) ~[?:?]
	at de.marcely.bedwars.dy.d(ArenaScheduler.java:375) ~[?:?]
	at de.marcely.bedwars.kl.C(ThreadedTicker.java:102) ~[?:?]
	at de.marcely.bedwars.kl.B(ThreadedTicker.java:88) ~[?:?]
	at de.marcely.bedwars.kl.z(ThreadedTicker.java:65) ~[?:?]
	at de.marcely.bedwars.kl.as(ThreadedTicker.java:36) ~[?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```